### PR TITLE
Add timezone display settings with UTC option

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Enhance GitHub Timestamps",
   "version": "1.1.6",
-  "permissions": ["tabs"],
+  "permissions": ["tabs", "storage"],
   "content_scripts": [
     {
       "matches": ["https://github.com/*"],
@@ -12,5 +12,12 @@
   ],
   "background": {
     "service_worker": "/src/01_frameworks-driver.layer/background/background.ts"
-  }
+  },
+  "options_page": "options.html",
+  "web_accessible_resources": [
+    {
+      "resources": ["assets/*"],
+      "matches": ["https://github.com/*"]
+    }
+  ]
 }

--- a/app/options.html
+++ b/app/options.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Enhance GitHub Timestamps - Settings</title>
+  <script type="module" src="src/options.tsx"></script>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/app/src/02_interface-adapter.layer/presenters/Content.presenter.ts
+++ b/app/src/02_interface-adapter.layer/presenters/Content.presenter.ts
@@ -25,7 +25,7 @@ export class ContentPresenter extends OutputPort<ConentOutputData, void> {
     const { element, theme, page, timestamp, age, timezone } = output;
     // text
     const dayjsInstance = timezone === "utc" ? dayjs(timestamp).utc() : dayjs(timestamp);
-    const timezoneLabel = timezone === "utc" ? " UTC" : "";
+    const timezoneLabel = timezone === "utc" ? "Z" : "";
     element.shadowRoot!.innerHTML = dayjsInstance.format("YYYY-MM-DD HH:mm") + timezoneLabel;
 
     // color

--- a/app/src/02_interface-adapter.layer/presenters/Content.presenter.ts
+++ b/app/src/02_interface-adapter.layer/presenters/Content.presenter.ts
@@ -25,8 +25,7 @@ export class ContentPresenter extends OutputPort<ConentOutputData, void> {
     const { element, theme, page, timestamp, age, timezone } = output;
     // text
     const dayjsInstance = timezone === "utc" ? dayjs(timestamp).utc() : dayjs(timestamp);
-    const timezoneLabel = timezone === "utc" ? "Z" : "";
-    element.shadowRoot!.innerHTML = dayjsInstance.format("YYYY-MM-DD HH:mm") + timezoneLabel;
+    element.shadowRoot!.innerHTML = dayjsInstance.format("YYYY-MM-DD HH:mm");
 
     // color
     const colors =

--- a/app/src/02_interface-adapter.layer/presenters/Content.presenter.ts
+++ b/app/src/02_interface-adapter.layer/presenters/Content.presenter.ts
@@ -1,6 +1,9 @@
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import { OutputPort } from "../../03_application.layer/output.boundary/OutputPort";
 import { ConentOutputData } from "../../03_application.layer/output.data/Content.od";
+
+dayjs.extend(utc);
 
 export class ContentPresenter extends OutputPort<ConentOutputData, void> {
   private static lightColors = [
@@ -19,9 +22,11 @@ export class ContentPresenter extends OutputPort<ConentOutputData, void> {
   ];
 
   present(output: ConentOutputData): void {
-    const { element, theme, page, timestamp, age } = output;
+    const { element, theme, page, timestamp, age, timezone } = output;
     // text
-    element.shadowRoot!.innerHTML = dayjs(timestamp).format("YYYY-MM-DD HH:mm");
+    const dayjsInstance = timezone === "utc" ? dayjs(timestamp).utc() : dayjs(timestamp);
+    const timezoneLabel = timezone === "utc" ? " UTC" : "";
+    element.shadowRoot!.innerHTML = dayjsInstance.format("YYYY-MM-DD HH:mm") + timezoneLabel;
 
     // color
     const colors =

--- a/app/src/03_application.layer/interactors/AbsoluteTime.interactor.ts
+++ b/app/src/03_application.layer/interactors/AbsoluteTime.interactor.ts
@@ -6,9 +6,12 @@ import { Timestamp } from "../../04_domain.layer/entites/Timestamp.vo";
 import { ContentInputData } from "../input.data/Content.id";
 import { InputPort } from "../input.boundary/InputPort";
 import { ContentEntity } from "../../04_domain.layer/entites/ContentEntity";
+import { SettingsService } from "../services/SettingsService";
 
 export class AbsoluteTimeInteractor extends InputPort<ContentInputData, void> {
   public async execute(input: ContentInputData): Promise<void> {
+    const settings = await SettingsService.getSettings();
+    
     const content = new ContentEntity({
       theme: new Theme(input.theme ?? "light"),
     });
@@ -37,6 +40,7 @@ export class AbsoluteTimeInteractor extends InputPort<ContentInputData, void> {
       page: content.page.value,
       timestamp: content.timestamp.value,
       age,
+      timezone: settings.timezone,
     });
   }
 }

--- a/app/src/03_application.layer/output.data/Content.od.ts
+++ b/app/src/03_application.layer/output.data/Content.od.ts
@@ -1,7 +1,10 @@
+import { TimezoneOption } from "../../04_domain.layer/entites/Settings.vo";
+
 export type ConentOutputData = {
   element: HTMLElement;
   theme: string;
   page: string;
   timestamp: number;
   age: number;
+  timezone: TimezoneOption;
 };

--- a/app/src/03_application.layer/services/SettingsService.ts
+++ b/app/src/03_application.layer/services/SettingsService.ts
@@ -1,0 +1,22 @@
+import { Settings, TimezoneOption } from "../../04_domain.layer/entites/Settings.vo";
+
+export class SettingsService {
+  public static async getSettings(): Promise<Settings> {
+    return new Promise((resolve) => {
+      chrome.storage.sync.get(Settings.default().value, (result) => {
+        const settings = {
+          timezone: (result.timezone as TimezoneOption) || "local"
+        };
+        resolve(new Settings(settings));
+      });
+    });
+  }
+
+  public static async saveSettings(settings: Settings): Promise<void> {
+    return new Promise((resolve) => {
+      chrome.storage.sync.set(settings.value, () => {
+        resolve();
+      });
+    });
+  }
+}

--- a/app/src/04_domain.layer/entites/Settings.vo.ts
+++ b/app/src/04_domain.layer/entites/Settings.vo.ts
@@ -1,0 +1,21 @@
+import { ValueObject } from "./shared/ValueObject";
+
+export type TimezoneOption = "local" | "utc";
+
+export class Settings extends ValueObject<{
+  timezone: TimezoneOption;
+}> {
+  protected validate(value: { timezone: TimezoneOption }): void {
+    if (!value.timezone || !["local", "utc"].includes(value.timezone)) {
+      throw new Error("Invalid timezone option");
+    }
+  }
+
+  public get timezone(): TimezoneOption {
+    return this.value.timezone;
+  }
+
+  public static default(): Settings {
+    return new Settings({ timezone: "local" });
+  }
+}

--- a/app/src/options.tsx
+++ b/app/src/options.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useEffect } from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+
+type TimezoneOption = "local" | "utc";
+
+interface Settings {
+  timezone: TimezoneOption;
+}
+
+const defaultSettings: Settings = {
+  timezone: "local",
+};
+
+function Options() {
+  const [settings, setSettings] = useState<Settings>(defaultSettings);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    // Load settings from storage
+    chrome.storage.sync.get(defaultSettings, (result) => {
+      setSettings(result as Settings);
+    });
+  }, []);
+
+  const handleTimezoneChange = (timezone: TimezoneOption) => {
+    const newSettings = { ...settings, timezone };
+    setSettings(newSettings);
+    
+    // Save to storage
+    chrome.storage.sync.set(newSettings, () => {
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    });
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-8">
+      <h1 className="text-3xl font-bold mb-8 text-gray-800">
+        Enhance GitHub Timestamps - Settings
+      </h1>
+      
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold mb-4 text-gray-700">
+            Timezone Display
+          </h2>
+          <p className="text-gray-600 mb-4">
+            Choose how timestamps should be displayed on GitHub pages.
+          </p>
+          
+          <div className="space-y-3">
+            <label className="flex items-center">
+              <input
+                type="radio"
+                name="timezone"
+                value="local"
+                checked={settings.timezone === "local"}
+                onChange={() => handleTimezoneChange("local")}
+                className="mr-3"
+              />
+              <div>
+                <span className="font-medium">Local Timezone</span>
+                <p className="text-sm text-gray-500">
+                  Display timestamps in your local timezone
+                </p>
+              </div>
+            </label>
+            
+            <label className="flex items-center">
+              <input
+                type="radio"
+                name="timezone"
+                value="utc"
+                checked={settings.timezone === "utc"}
+                onChange={() => handleTimezoneChange("utc")}
+                className="mr-3"
+              />
+              <div>
+                <span className="font-medium">UTC</span>
+                <p className="text-sm text-gray-500">
+                  Display timestamps in UTC (Coordinated Universal Time)
+                </p>
+              </div>
+            </label>
+          </div>
+        </div>
+        
+        {saved && (
+          <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded">
+            Settings saved successfully!
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <Options />
+  </React.StrictMode>
+);

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -9,4 +9,11 @@ export default defineConfig({
   server: {
     port: 3000,
   },
+  build: {
+    rollupOptions: {
+      input: {
+        options: "options.html",
+      },
+    },
+  },
 });


### PR DESCRIPTION
This adds a settings page with a "Timezone Display" setting that allows the configuration of UTC timezone instead of local ones.

Fixes https://github.com/44103/enhance-github-timestamps/issues/33

95% of this was written by Claude Code. I have no idea what I'm doing, but I did review the code and it makes sense to me.

<img width="671" height="351" alt="image" src="https://github.com/user-attachments/assets/a8a9e958-7d0f-49ea-8816-c52197472e11" />
